### PR TITLE
Add git conflicts shared syntax

### DIFF
--- a/syntaxes/shared/gitconflicts.sublime-syntax
+++ b/syntaxes/shared/gitconflicts.sublime-syntax
@@ -1,0 +1,17 @@
+%YAML1.2
+---
+hidden: true
+scope: ...
+
+contexts:
+  main:
+    - match: '^<<<<<<<.*\n'
+      scope: invalid.illegal
+      push: git-conflict-head
+    - match: '^>>>>>>>.*\n'
+      scope: invalid.illegal
+
+  git-conflict-head:
+    - match: '^=======.*\n'
+      scope: invalid.illegal
+      pop: true


### PR DESCRIPTION
I would like to add support for highlighting of git conflicts.

In native packages of Sublime text I managed to do so just to add `prototype`: phts/Packages@f10a67468d49725949f60ff4b821d1a0b807b555

But here in Naomi I didn't managed to do so. It seems there will be not a simple change.

In this pull request I added syntax file for git conflicts only.

Could you help me to add this syntax into JS, CSS and other supported syntaxes? (Of course if you interested in such pull request :) )