### PR TITLE
Add official Prettier meta_scope for styled-components (#196)

### DIFF
--- a/syntaxes/fjsx15/literal/string/styled-component.sublime-syntax
+++ b/syntaxes/fjsx15/literal/string/styled-component.sublime-syntax
@@ -201,7 +201,7 @@ contexts:
 
   styled-component-content-keyframes:
     - clear_scopes: true
-    - meta_content_scope: source.css
+    - meta_content_scope: source.css.embedded.js
     - include: comment-no-pop
     - include: shared-content
     - match: (?=\S)

--- a/syntaxes/fjsx15/literal/string/styled-component.sublime-syntax
+++ b/syntaxes/fjsx15/literal/string/styled-component.sublime-syntax
@@ -153,7 +153,6 @@ contexts:
         1: punctuation.accessor.js.fjsx15
         2: support.function.styled-component.js.fjsx15
       set: styled-component-begin
-
   pop-now:
     - match: ""
       pop: true
@@ -190,6 +189,7 @@ contexts:
 
   styled-component-content:
     - clear_scopes: true
+    - meta_scope: source.css.embedded.js
     - meta_content_scope: source.css
     - include: comment-no-pop
     - include: shared-content

--- a/syntaxes/fjsx15/literal/string/styled-component.sublime-syntax
+++ b/syntaxes/fjsx15/literal/string/styled-component.sublime-syntax
@@ -189,8 +189,7 @@ contexts:
 
   styled-component-content:
     - clear_scopes: true
-    - meta_scope: source.css.embedded.js
-    - meta_content_scope: source.css
+    - meta_content_scope: source.css.embedded.js
     - include: comment-no-pop
     - include: shared-content
     # Recover ruleset block.


### PR DESCRIPTION
Use proper scoping when inside of styled component blocks within js[x] files. Previously JsPrettier would throw an error if attempting to format while inside one of these blocks.