### PR TITLE
Fixed Markdown wrapping when line-wrapping enabled

### DIFF
--- a/syntaxes/naomi.md1.sublime-syntax
+++ b/syntaxes/naomi.md1.sublime-syntax
@@ -27,5 +27,11 @@ contexts:
   entry:
     - include: Packages/Naomi/syntaxes/md1/header.sublime-syntax
     - include: Packages/Naomi/syntaxes/md1/code-block.sublime-syntax
-    - match: ""
+    - match: |-
+        (?x)^
+        (?= [ ]{,3}>
+        | ([ ]{4}|\t)(?!$)
+        | [#]{1,6}\s*+
+        | [ ]{,3}(?<marker>[-*_])([ ]{,2}\k<marker>){2,}[ \t]*+$
+        )
       pop: true


### PR DESCRIPTION
This was originally wrapping by letter, but adding this match code allows it to wrap by word.

This match code was taken from the now-defunct MarkdownEditing plugin.