### PR TITLE
Don't close tag that's already closed

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -417,6 +417,10 @@
     "operand": true,
     "match_all": true
   }, {
+    "key": "following_text",
+    "operator": "not_regex_contains",
+    "operand": ">"
+  }, {
     "key": "setting.command_mode",
     "operand": false
   }]


### PR DESCRIPTION
This fixes the primary issue described in #216, seen here:

![](https://camo.githubusercontent.com/de8b9677f17a4f5030b55cd9d1d4269ce5b62458/68747470733a2f2f696d6775722e636f6d2f4470766a644f332e676966)

There is another problem with multi-cursors described in that issue, and that may require a larger fix.